### PR TITLE
Added sock_recv_msg, sock_send_msg

### DIFF
--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -615,6 +615,36 @@
   )
 )
 
+;;; Socket control message level.
+(typename $sock_cmsg_level
+  (enum (@witx tag u16)
+    ;;; POSIX SOL_SOCKET.
+    $socket
+  )
+)
+
+;;; Socket control message type.
+(typename $sock_cmsg_type
+  (enum (@witx tag u16)
+    ;;; POSIX SCM_RIGHTS. Payload is an array of file descriptors.
+    $rights
+  )
+)
+
+;;; Socket control message header.
+;;;
+;;; Payload bytes immediately follow this header in the control buffer.
+(typename $sock_cmsg
+  (record
+    ;;; Header plus payload size in bytes.
+    (field $cmsg_len $size)
+    ;;; Control message level.
+    (field $cmsg_level $sock_cmsg_level)
+    ;;; Control message type.
+    (field $cmsg_type $sock_cmsg_type)
+  )
+)
+
 (typename hidden $sdflags
   (flags (@witx repr u8)
     $hidden

--- a/phases/snapshot/witx/wasix_v1.witx
+++ b/phases/snapshot/witx/wasix_v1.witx
@@ -826,6 +826,49 @@
     (result $error (expected $size (error $errno)))
   )
 
+  ;;; Receive a message, optional peer address, and optional ancillary data from
+  ;;; a socket.
+  ;;;
+  ;;; Note: This is similar to `recvmsg` in POSIX, though it also supports
+  ;;; reading the data into multiple buffers in the manner of `readv`.
+  (@interface func (export "sock_recv_msg")
+    (param $fd $fd)
+    ;;; List of scatter/gather vectors to which to store data.
+    (param $ri_data $iovec_array)
+    ;;; Message flags.
+    (param $ri_flags $riflags)
+    ;;; Optional output peer address. Null means the caller does not request it.
+    (param $addr (@witx pointer $addr_port))
+    ;;; Output control-message buffer.
+    (param $ro_control (@witx pointer u8))
+    ;;; Capacity of ro_control in bytes.
+    (param $ro_control_len $size)
+    ;;; Number of bytes stored in ri_data, message flags, and number of bytes
+    ;;; stored in ro_control.
+    (result $error (expected (tuple $size $roflags $size) (error $errno)))
+  )
+
+  ;;; Send a message, optional peer address, and optional ancillary data on a
+  ;;; socket.
+  ;;;
+  ;;; Note: This is similar to `sendmsg` in POSIX, though it also supports
+  ;;; writing the data from multiple buffers in the manner of `writev`.
+  (@interface func (export "sock_send_msg")
+    (param $fd $fd)
+    ;;; List of scatter/gather vectors from which to retrieve data.
+    (param $si_data $ciovec_array)
+    ;;; Message flags.
+    (param $si_flags $siflags)
+    ;;; Optional peer address. Null means connected socket / no explicit address.
+    (param $addr (@witx const_pointer $addr_port))
+    ;;; Input control-message buffer.
+    (param $si_control (@witx const_pointer u8))
+    ;;; Size of si_control in bytes.
+    (param $si_control_len $size)
+    ;;; Number of bytes transmitted.
+    (result $error (expected $size (error $errno)))
+  )
+
   ;;; Sends the entire contents of a file down a socket
   (@interface func (export "sock_send_file")
     (param $out_fd $fd)


### PR DESCRIPTION
## Summary

Adds WASIX WITX ABI definitions for `sock_send_msg` and `sock_recv_msg`.

These syscalls model the WASIX side of POSIX `sendmsg()` / `recvmsg()` using:

- existing scatter/gather data iovecs,
- an optional socket address pointer,
- a raw control-message pointer and byte length,
- explicit returned data/control lengths.

This also adds the minimal WASIX control-message ABI shape needed for future ancillary data support:

- `sock_cmsg`
- `sock_cmsg_level`
- `sock_cmsg_type`
- `SOCKET` control-message level
- `RIGHTS` control-message type, corresponding to POSIX `SCM_RIGHTS`

## Motivation

`libuv` and Node-style runtimes use `sendmsg()` / `recvmsg()` for IPC paths, especially socketpair-based communication and file-descriptor passing. WASIX did not have ABI-level operations that could represent these calls, which forced libc/runtime layers either to avoid the POSIX path or to use incomplete workarounds.

This WITX change gives `wasix-libc` a proper ABI target for POSIX-compatible `sendmsg()` / `recvmsg()` wrappers, and gives Wasmer a runtime syscall surface where payload transfer works now and ancillary/control-message handling can be implemented cleanly next.

Related implementation work lives in the matching `wasix-libc` and Wasmer PRs.